### PR TITLE
fix: set correct executable name for opentofu binary

### DIFF
--- a/internal/terraform/discovery/discovery_unix.go
+++ b/internal/terraform/discovery/discovery_unix.go
@@ -8,4 +8,4 @@
 
 package discovery
 
-const executableName = "opentofu"
+const executableName = "tofu"

--- a/internal/terraform/discovery/discovery_windows.go
+++ b/internal/terraform/discovery/discovery_windows.go
@@ -5,4 +5,4 @@
 
 package discovery
 
-const executableName = "terraform.exe"
+const executableName = "tofu.exe"


### PR DESCRIPTION
Hi everyone!

I think, i found the reason for the issue #10. There is a discovery functionality inside the tool, which looks for hardcoded binary names. On unix is searches for `opentofu` instead of the newer name `tofu` and on windows it stills searches for `terraform.exe`.

This PR will fix this.
I tested the change on my local machine on neovim as lsp client. 
Based on the code of the main branch, the editor throws errors at formatting, because the binary was not discovered. 
> "'2025/02/04 21:53:05 rpc_logger.go:50: Error for "textDocument/formatting" (ID 5): [-32098] Terraform (CLI) is required. Please install Terraform or make it available in $PATH'"

This got fixed by this PR, opentofu-ls was able to find my `tofu` binary :)

> "2025/02/04 22:08:01 formatting.go:47: formatting document via "/usr/bin/tofu"\n