### PR TITLE
Enable blank issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Provider-related Feedback and Questions
     url: https://registry.terraform.io/browse/providers


### PR DESCRIPTION
None of the current issue templates are relevant for some tasks required for the initial release.
We allow blank issues for now, and should decide on the general policy regarding blank issues in this repository after the initial work is complete.